### PR TITLE
Fix URLs to sources

### DIFF
--- a/safe_environment.md
+++ b/safe_environment.md
@@ -23,4 +23,4 @@ To further our mission of making our events a supportive, non-threatening enviro
   - We promote inclusive learning spaces. We encourage anyone who is feeling less than familiar with terminology, concepts, or context to ask questions in the spirit of personal growth.
 
 ## Sources
-This definition has heavily borrowed from [Values of the SoCraTes Conference](https://www.socrates-conference.de/values.html) and the [Safe Space Policy of LadyHacks](http://ladyhacks.org/about/safe-space-policy).
+This definition has heavily borrowed from [Values of the SoCraTes Conference](https://www.socrates-conference.de/values) and the [Safe Space Policy of LadyHacks](http://ladyhacks.org/about/safe-space-policy).


### PR DESCRIPTION
The source documents are now found under new URLs. Since there are no redirects, we have to update the links in the document.

The link at the socrates-conference just had its `.html` removed, but the page at LadyHacks has completely gone missing. Even their own internal links are dead. I notified them via their contact form, let's hope they fix it soon.